### PR TITLE
do not link the bin/ dir

### DIFF
--- a/lib/capistrano/deploy_mate_defaults.rb
+++ b/lib/capistrano/deploy_mate_defaults.rb
@@ -9,7 +9,7 @@ set :rvm_ruby_version, "ruby-2.2.0"
 set :rvm_map_bins, %w{gem rake ruby rvmsudo bundle}
 
 set :deploy_to, "/srv/#{fetch(:application)}"
-set :linked_dirs, %w{bin log vendor/bundle system/pids system/sockets public/assets}
+set :linked_dirs, %w{log vendor/bundle system/pids system/sockets public/assets}
 
 set :keep_releases, 3
 set :ssh_options, { forward_agent: true }


### PR DESCRIPTION
- deploying a rails 4.2.1 app results in empty <appname>/bin dir in current_path. The app works fine, but trying to run a rails console directly on server does not (bundle exec rails c <envname>)
  -> removing the bin dir from linked dirs solved the issue
