### PR TITLE
move all invoke calls out of on blocks

### DIFF
--- a/lib/capistrano/deploy_mate_defaults.rb
+++ b/lib/capistrano/deploy_mate_defaults.rb
@@ -25,9 +25,7 @@ set :app_server, "unicorn" # default to unicorn if nothing set
 namespace :deploy do
   desc 'Restart application'
   task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      invoke "bluepill:restart"
-    end
+    invoke "bluepill:restart"
   end
 
   desc 'Ensure that the app folder is present'

--- a/lib/capistrano/tasks/bluepill.rake
+++ b/lib/capistrano/tasks/bluepill.rake
@@ -11,19 +11,29 @@ namespace :bluepill do
   desc "Starts bluepill"
   task :start do
     on roles(:app) do
-      sudo "start bluepill"
+      if !bluepill_running?
+        sudo "start bluepill"
+      else
+        info "No need to start bluepill, it is running!"
+      end
     end
   end
 
   desc "Stops app server"
   task :stop do
     on roles(:app) do
-      sudo "stop bluepill"
+      if bluepill_running?
+        sudo "stop bluepill"
+      else
+        "Can't stop bluepill because it's not running!"
+      end
     end
   end
 
   desc "Restarts/Reloads app gracefully"
   task :restart do
+    invoke "bluepill:start"
+
     on roles(:app) do
       if bluepill_running?
         if pill_running?(fetch(:app_server))
@@ -31,11 +41,10 @@ namespace :bluepill do
         else
           execute :rvmsudo, :bluepill, fetch(:application), :start
         end
-      else
-        invoke "bluepill:start"
-        invoke "nginx:reload"
       end
     end
+
+    invoke "nginx:reload"
   end
   before :restart, 'rvm:hook'
 end

--- a/lib/capistrano/tasks/machine.rake
+++ b/lib/capistrano/tasks/machine.rake
@@ -6,24 +6,24 @@ namespace :machine do
   task :init do
     on roles(:app) do
       apt_get_update
-      invoke "machine:install:htop"
-      invoke "machine:install:language_pack_de"
-      invoke "machine:install:unattended_upgrades"
-      invoke "machine:install:ntp"
-      invoke "machine:install:git"
-      invoke "machine:install:nginx"
-      invoke "machine:install:fail2ban"
-      invoke "machine:install:rvm"
-      invoke "machine:install:ruby"
-      invoke "machine:install:set_defaults"
-      invoke "machine:install:bluepill"
-      invoke "machine:install:bundler"
-      invoke "machine:install:nodejs"
-      invoke "machine:install:elasticsearch"
-      invoke "machine:install:imagemagick" if fetch(:imagemagick)
-      invoke "machine:install:mysql_dev" if fetch(:db_engine) == "mysql"
-      invoke "machine:install:postgres_dev" if fetch(:db_engine) == "postgresql"
     end
+    invoke "machine:install:htop"
+    invoke "machine:install:language_pack_de"
+    invoke "machine:install:unattended_upgrades"
+    invoke "machine:install:ntp"
+    invoke "machine:install:git"
+    invoke "machine:install:nginx"
+    invoke "machine:install:fail2ban"
+    invoke "machine:install:rvm"
+    invoke "machine:install:ruby"
+    invoke "machine:install:set_defaults"
+    invoke "machine:install:bluepill"
+    invoke "machine:install:bundler"
+    invoke "machine:install:nodejs"
+    invoke "machine:install:elasticsearch"
+    invoke "machine:install:imagemagick" if fetch(:imagemagick)
+    invoke "machine:install:mysql_dev" if fetch(:db_engine) == "mysql"
+    invoke "machine:install:postgres_dev" if fetch(:db_engine) == "postgresql"
   end
   before "machine:init", "machine:check_ubuntu_user"
   before "deploy", "machine:check_ubuntu_user"

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -15,10 +15,9 @@ namespace :nginx do
       end
 
       execute "mkdir -p #{shared_path}/log"
-
-      invoke "nginx:enable_site"
-      invoke "nginx:reload"
     end
+    invoke "nginx:enable_site"
+    invoke "nginx:reload"
   end
 
   desc "Enable the app page for nginx"


### PR DESCRIPTION
it is not intended to use invoke calls inside on blocks.
current implementation works with capistrano 3.3.x but breaks with 3.4.x
see: https://github.com/capistrano/capistrano/issues/741

fixes #12 