### PR TITLE
Allow to use env vars provided by dotenv in puma config

### DIFF
--- a/lib/capistrano/configs/puma.rb.erb
+++ b/lib/capistrano/configs/puma.rb.erb
@@ -16,7 +16,7 @@ end
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = <%= ENV.fetch("PUMA_THREADS", fetch(:puma_threads)) %>
+threads_count = ENV.fetch("PUMA_THREADS", <%= fetch(:puma_threads) %>)
 threads threads_count, threads_count
 
 # Specifies the `environment` that Puma will run in.
@@ -29,7 +29,7 @@ environment environment_name
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers <%= ENV.fetch("PUMA_WORKERS", fetch(:puma_workers)) %>
+workers ENV.fetch("PUMA_WORKERS", <%= fetch(:puma_workers) %>)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/lib/capistrano/configs/puma.rb.erb
+++ b/lib/capistrano/configs/puma.rb.erb
@@ -5,7 +5,8 @@ environment_name = "<%= fetch(:environment) %>"
 
 begin
   require 'dotenv'
-  Dotenv.load("#{shared_path}/.env.#{environment_name}")
+  dotenv_path = '<%= fetch(:dotenv_path, shared_path.join(".env.#{fetch(:environment)}")) %>'
+  Dotenv.load(dotenv_path)
 rescue LoadError
   puts "Dotenv not found, skipping load of env vars..."
 end

--- a/lib/capistrano/configs/puma.rb.erb
+++ b/lib/capistrano/configs/puma.rb.erb
@@ -1,6 +1,14 @@
 # puma configuration
 
 shared_path = "<%= shared_path %>"
+environment_name = "<%= fetch(:environment) %>"
+
+begin
+  require 'dotenv'
+  Dotenv.load("#{shared_path}/.env.#{environment_name}")
+rescue LoadError
+  puts "Dotenv not found, skipping load of env vars..."
+end
 
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
@@ -8,12 +16,12 @@ shared_path = "<%= shared_path %>"
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = <%= fetch(:puma_threads) %>
+threads_count = <%= ENV.fetch("PUMA_THREADS", fetch(:puma_threads)) %>
 threads threads_count, threads_count
 
 # Specifies the `environment` that Puma will run in.
 #
-environment "<%= fetch(:environment) %>"
+environment environment_name
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -21,7 +29,7 @@ environment "<%= fetch(:environment) %>"
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers <%= fetch(:puma_workers) %>
+workers <%= ENV.fetch("PUMA_WORKERS", fetch(:puma_workers)) %>
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
- load dotenv in puma config if possible
- simple change of puma threads/workers with env